### PR TITLE
fix: Add `MEDIA_URL` to  settings.py-tpl

### DIFF
--- a/project_name/settings.py-tpl
+++ b/project_name/settings.py-tpl
@@ -231,4 +231,5 @@ INTERNAL_IPS = [
 # Add project-wide static files directory
 # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#media-root
 
+MEDIA_URL = "/media/"
 MEDIA_ROOT = str(BASE_DIR.parent / "media")


### PR DESCRIPTION
Fixes https://github.com/django-cms/django-cms/issues/7782

If no media URL is set, it will catch all otherwise unresolved URLs. This prevents the `APPEND_SLASH` setting to kick in.