### PR TITLE
feat: Add djangocms-simple-admin-style to project 

### DIFF
--- a/project_name/settings.py-tpl
+++ b/project_name/settings.py-tpl
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'djangocms_admin_style',
+    'djangocms_simple_admin_style',
 
     'django.contrib.admin',
     'django.contrib.auth',

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ djangocms-frontend>=2.0.0a1
 django-filer
 djangocms-text
 django-fsm<3
+djangocms-simple-admnin-style


### PR DESCRIPTION
Djangocms-admin-style has some styling inconsistencies with newer Django versions.