### PR TITLE
typo fix

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,4 @@ djangocms-frontend>=2.0.0a1
 django-filer
 djangocms-text
 django-fsm<3
-djangocms-simple-admnin-style
+djangocms-simple-admin-style


### PR DESCRIPTION
- fix typo in requirements.in, 
- this is causing new project initiation to break