### PR TITLE
fix: route the CMS catch-all through i18n_patterns

### DIFF
--- a/djangocms_install_rules.json
+++ b/djangocms_install_rules.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/django-cms/cms-template/main/djangocms_install_rules.schema.v1.json",
-    "comment": "Rules used by `djangocms .` to add django CMS to an existing project. Fetched from the cms-template repository (branch matching the installed django CMS major.minor), with this file as the bundled fallback. Each `when` condition may contain a `flag` (truthy command option) and/or a `mode` (list of matching --mode values). For installed_apps and middleware a rule may also carry a `before` or `after` anchor (an existing entry) for positional insertion; otherwise items are appended.",
+    "comment": "Rules used by `djangocms .` to add django CMS to an existing project. Fetched from the cms-template repository (branch matching the installed django CMS major.minor), with this file as the bundled fallback. Each `when` condition may contain a `flag` (truthy command option) and/or a `mode` (list of matching --mode values). For installed_apps and middleware a rule may also carry a `before` or `after` anchor (an existing entry) for positional insertion; otherwise items are appended. A url rule may carry `\"i18n\": true` to route its pattern through `i18n_patterns()` (so the CMS catch-all keeps its language prefix) when the project's urls.py already uses i18n_patterns; otherwise the pattern is added to the plain urlpatterns list.",
     "installed_apps": [
         {"items": ["djangocms_simple_admin_style"], "before": "django.contrib.admin"},
         {
@@ -72,7 +72,7 @@
     "urls": [
         {"pattern": "path(\"api/\", include(\"djangocms_rest.urls\"))", "when": {"mode": ["headless", "hybrid"]}},
         {"pattern": "path(\"taggit_autosuggest/\", include(\"taggit_autosuggest.urls\"))", "when": {"flag": "stories"}},
-        {"pattern": "path(\"\", include(\"cms.urls\"))", "when": {"mode": ["traditional", "hybrid"]}}
+        {"pattern": "path(\"\", include(\"cms.urls\"))", "i18n": true, "when": {"mode": ["traditional", "hybrid"]}}
     ],
     "packages": {
         "filer": "django-filer"

--- a/djangocms_install_rules.schema.v1.json
+++ b/djangocms_install_rules.schema.v1.json
@@ -208,6 +208,10 @@
                     "type": "string",
                     "description": "Python expression for the URL pattern, e.g. path(\"\", include(\"cms.urls\"))."
                 },
+                "i18n": {
+                    "type": "boolean",
+                    "description": "Route this pattern through i18n_patterns() (so it keeps a language prefix) when the project's urls.py already uses i18n_patterns; otherwise it is added to the plain urlpatterns list. Used for the CMS catch-all."
+                },
                 "when": {
                     "$ref": "#/definitions/when"
                 },


### PR DESCRIPTION
## Problem

`djangocms .` (the simplified installer that adds django CMS to an existing project, in [django-cms#feat/simplified-project-creation](https://github.com/django-cms/django-cms)) reads `djangocms_install_rules.json` from this repo and inserts `path("", include("cms.urls"))` into the project's `urls.py`. It was always appended to the plain `urlpatterns` list.

That strips the language prefix from CMS pages and directly contradicts the [documented manual installation](https://docs.django-cms.org/), which requires the CMS catch-all to live **inside** `i18n_patterns()`:

```python
urlpatterns += i18n_patterns(
    path("", include("cms.urls")),  # must be language-prefixed
)
```

## Change

- Mark the CMS catch-all url rule with `"i18n": true`. The installer uses this to route the pattern through a `urlpatterns += i18n_patterns(...)` block **when the project's `urls.py` already uses `i18n_patterns`** — otherwise it falls back to the plain `urlpatterns` list (unchanged behaviour). Non-i18n routes (the headless `djangocms_rest` API) stay in the plain list.
- Document the flag in the rules `comment`.
- Add `i18n` (optional boolean) to `urlRule` in `djangocms_install_rules.schema.v1.json`. The schema uses `additionalProperties: false`, so without this the rules file would fail validation.

The matching installer-side change (the `update_urls` logic that honours this flag, plus tests) lands in the django-cms repo on `feat/simplified-project-creation`. This PR is the data/schema half so a successful remote fetch doesn't override the bundled flag.

Validated: both JSON files parse and `djangocms_install_rules.json` passes `jsonschema` validation against the updated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)